### PR TITLE
Still the official movie url

### DIFF
--- a/lib/yay_imdbs.rb
+++ b/lib/yay_imdbs.rb
@@ -148,7 +148,7 @@ class YayImdbs
 	
     def get_official_site_url(value, imdb_id)
         value = value.match(/<a href="(.*?)">Official site<\/a>/)
-        if 
+        if value.nil?
             value = get_official_sites_page(imdb_id).inner_html.match(/<a href="(.*?)">Official site<\/a>/)
         end
         return $1


### PR DESCRIPTION
Movies like Avatar have the official site in the '/officialsites' page, rather than on the main one. I'm still a bit green in ruby on rails, so maybe there's a better way of doing it. ))
